### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/CustomDump.podspec
+++ b/CustomDump.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                   = 'CustomDump'
-  s.version                = '0.3.0'
+  s.version                = '0.4.0'
   s.summary                = 'A collection of tools for debugging, diffing, and testing your application\'s data structures.'
   s.homepage               = 'https://github.com/crunchyroll/swift-custom-dump'
   s.license                = { :type => 'MIT', :file => 'LICENSE' }


### PR DESCRIPTION
Jira: CXIOS-7755

### Background
<!-- In contrast to the description in the Jira ticket this should provide as much technical background as possible -->
In preparation for the CR iOS 4.18.0 release, we need to bump the versions for the in-house libraries that were updated for the current release.

### What has been done?
1. Bumped version to `0.4.0` because 0.3.0 was already taken.

### How to test?
1. Make sure `*.podspec` file was updated with the correct version

### Checklist
<!-- Please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
- [x] I've run tests before opening PR

[Reviewer Guidelines](https://github.com/crunchyroll/ios-resources/blob/master/CODE_REVIEW_GUIDELINES.md)